### PR TITLE
Fix HTTP caching docs

### DIFF
--- a/content/de/learn/responses.md
+++ b/content/de/learn/responses.md
@@ -141,7 +141,7 @@ Wenn Sie Ihre gesamte Antwort zwischenspeichern möchten, können Sie die `cache
 
 // Dies zwischenspeichert die Antwort für 5 Minuten
 Flight::route('/nachrichten', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Dieser Inhalt wird zwischengespeichert.';
 });
 

--- a/content/en/learn/responses.md
+++ b/content/en/learn/responses.md
@@ -149,14 +149,14 @@ If you want to cache your whole response, you can use the `cache()` method and p
 
 // This will cache the response for 5 minutes
 Flight::route('/news', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'This content will be cached.';
 });
 
 // Alternatively, you can use a string that you would pass
 // to the strtotime() method
 Flight::route('/news', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'This content will be cached.';
 });
 ```

--- a/content/es/learn/responses.md
+++ b/content/es/learn/responses.md
@@ -141,7 +141,7 @@ Si deseas cachear toda tu respuesta, puedes utilizar el método `cache()` y pasa
 
 // Esto cacheará la respuesta durante 5 minutos
 Flight::route('/noticias', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Este contenido será almacenado en caché.';
 });
 

--- a/content/fr/learn/responses.md
+++ b/content/fr/learn/responses.md
@@ -148,14 +148,14 @@ Si vous voulez mettre en cache toute votre réponse, vous pouvez utiliser la mé
 
 // Cela mettra en cache la réponse pendant 5 minutes
 Flight::route('/actualites', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Ce contenu sera mis en cache.';
 });
 
 // Alternativement, vous pouvez utiliser une chaîne que vous passeriez
 // à la méthode strtotime()
 Flight::route('/actualites', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'Ce contenu sera mis en cache.';
 });
 ```

--- a/content/ja/learn/responses.md
+++ b/content/ja/learn/responses.md
@@ -139,13 +139,13 @@ Flightは、HTTPレベルのキャッシングのための組込みサポート�
 
 // これにより、レスポンスが5分間キャッシュされます
 Flight::route('/news', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'このコンテンツはキャッシュされます。';
 });
 
 // 代わりに、strtotime（）メソッドに渡す文字列を使用することもできます
 Flight::route('/news', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'このコンテンツはキャッシュされます。';
 });
 ```

--- a/content/ko/learn/responses.md
+++ b/content/ko/learn/responses.md
@@ -145,13 +145,13 @@ Flight는 HTTP 수준 캐싱을 위한 내장 지원을 제공합니다. 캐싱 
 
 // 이것은 응답을 5분 동안 캐시합니다
 Flight::route('/news', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo '이 콘텐츠는 캐시됩니다.';
 });
 
 // 또는 strtotime() 메소드에 전달할 문자열을 사용할 수도 있습니다
 Flight::route('/news', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo '이 콘텐츠는 캐시됩니다.';
 });
 ```

--- a/content/lv/learn/responses.md
+++ b/content/lv/learn/responses.md
@@ -149,14 +149,14 @@ Ja vēlaties kešot visu atbildi, jūs varat izmantot `cache()` metodi un padot 
 
 // Tas kešos atbildi uz 5 minūtēm
 Flight::route('/jaunumi', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Šis saturs tiks kešots.';
 });
 
 // Kā alternatīvu, jūs varat izmantot tekstu, ko padodat
 // funkcijai strtotime()
 Flight::route('/jaunumi', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'Šis saturs tiks kešots.';
 });
 ```

--- a/content/pt/learn/responses.md
+++ b/content/pt/learn/responses.md
@@ -146,14 +146,14 @@ Se você quiser armazenar em cache toda a resposta, você pode usar o método `c
 
 // Isso armazenará em cache a resposta por 5 minutos
 Flight::route('/noticias', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Este conteúdo será armazenado em cache.';
 });
 
 // Alternativamente, você pode usar uma string que passaria
 // para o método strtotime()
 Flight::route('/noticias', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'Este conteúdo será armazenado em cache.';
 });
 ```

--- a/content/ru/learn/responses.md
+++ b/content/ru/learn/responses.md
@@ -141,14 +141,14 @@ Flight предоставляет встроенную поддержку кэш
 
 // Это закэширует ответ на 5 минут
 Flight::route('/news', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo 'Этот контент будет кэшироваться.';
 });
 
 // Кроме того, вы можете использовать строку, которую вы бы передали
 // методу strtotime()
 Flight::route('/news', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo 'Этот контент будет кэшироваться.';
 });
 ```

--- a/content/zh/learn/responses.md
+++ b/content/zh/learn/responses.md
@@ -141,13 +141,13 @@ Flight 提供内置支持的 HTTP 级缓存。如果满足缓存条件，Flight 
 
 // 这将为 5 分钟缓存响应
 Flight::route('/news', function () {
-  Flight::cache(time() + 300);
+  Flight::response()->cache(time() + 300);
   echo '这个内容将被缓存。';
 });
 
 // 或者，您可以使用会传递给 strtotime() 方法的字符串
 Flight::route('/news', function () {
-  Flight::cache('+5 minutes');
+  Flight::response()->cache('+5 minutes');
   echo '这个内容将被缓存。';
 });
 ```


### PR DESCRIPTION
The cache function actually falls under the response object. Docs for `etag` and `lastModified` are correct as documented, however