### PR TITLE
Updated Security.md docs with the new Response::header() signature

### DIFF
--- a/content/en/learn/security.md
+++ b/content/en/learn/security.md
@@ -241,19 +241,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -275,7 +276,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $allowed)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/es/learn/security.md
+++ b/content/es/learn/security.md
@@ -240,19 +240,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -274,7 +275,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $permitidos)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/fr/learn/security.md
+++ b/content/fr/learn/security.md
@@ -242,19 +242,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -276,7 +277,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $allowed)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/ja/learn/security.md
+++ b/content/ja/learn/security.md
@@ -241,19 +241,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -275,7 +276,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $allowed)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/ko/learn/security.md
+++ b/content/ko/learn/security.md
@@ -240,19 +240,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -274,7 +275,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $allowed)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/pt/learn/security.md
+++ b/content/pt/learn/security.md
@@ -240,19 +240,19 @@ class CorsMiddleware
 		$resposta = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->permitirOrigens();
-			$resposta->header('Access-Control-Allow-Credentials: true');
-			$resposta->header('Access-Control-Max-Age: 86400');
+			$resposta->header('Access-Control-Allow-Credentials', true;
+			$resposta->header('Access-Control-Max-Age', 86400);
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$resposta->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$resposta->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers", $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$resposta->send();
@@ -274,7 +274,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $permitido)) {
 			$resposta = Flight::response();
-			$resposta->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$resposta->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }

--- a/content/ru/learn/security.md
+++ b/content/ru/learn/security.md
@@ -241,19 +241,20 @@ class CorsMiddleware
 		$response = Flight::response();
 		if (isset($_SERVER['HTTP_ORIGIN'])) {
 			$this->allowOrigins();
-			$response->header('Access-Control-Allow-Credentials: true');
-			$response->header('Access-Control-Max-Age: 86400');
+			$response->header('Access-Control-Allow-Credentials', 'true');
+			$response->header('Access-Control-Max-Age', '86400');
 		}
 
 		if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
 				$response->header(
-					'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS'
+					'Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
 				);
 			}
 			if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
 				$response->header(
-					"Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}"
+					"Access-Control-Allow-Headers",
+					$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
 				);
 			}
 			$response->send();
@@ -275,7 +276,7 @@ class CorsMiddleware
 
 		if (in_array($_SERVER['HTTP_ORIGIN'], $allowed)) {
 			$response = Flight::response();
-			$response->header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+			$response->header("Access-Control-Allow-Origin", $_SERVER['HTTP_ORIGIN']);
 		}
 	}
 }


### PR DESCRIPTION
Response::header() now requires two parameters (name and value) for each header instead of one (colon separated string).
CORS examples are working now.