### PR TITLE
Fix CommentTemplate API documentation errors

### DIFF
--- a/content/v3/en/awesome-plugins/comment_template.md
+++ b/content/v3/en/awesome-plugins/comment_template.md
@@ -33,14 +33,14 @@ use KnifeLemon\CommentTemplate\Engine;
 $app = Flight::app();
 
 $app->register('view', Engine::class, [], function (Engine $engine) use ($app) {
-    // Where your template files are stored
-    $engine->setTemplatesPath(__DIR__ . '/views');
+    // Root directory (where index.php is) - the document root of your web application
+    $engine->setPublicPath(__DIR__);
     
-    // Where your public assets will be served from
-    $engine->setPublicPath(__DIR__ . '/public');
+    // Template files directory - supports both relative and absolute paths
+    $engine->setSkinPath('views');             // Relative to public path
     
-    // Where compiled assets will be stored
-    $engine->setAssetPath('assets');
+    // Where compiled assets will be stored - supports both relative and absolute paths
+    $engine->setAssetPath('assets');           // Relative to public path
     
     // Template file extension
     $engine->setFileExtension('.php');
@@ -63,9 +63,9 @@ $app = Flight::app();
 
 // __construct(string $publicPath = "", string $skinPath = "", string $assetPath = "", string $fileExtension = "")
 $app->register('view', Engine::class, [
-    __DIR__ . '/public',    // publicPath - where assets will be served from
-    __DIR__ . '/views',     // skinPath - where template files are stored  
-    'assets',               // assetPath - where compiled assets will be stored
+    __DIR__,                // publicPath - root directory (where index.php is)
+    'views',                // skinPath - templates path (supports relative/absolute)
+    'assets',               // assetPath - compiled assets path (supports relative/absolute)
     '.php'                  // fileExtension - template file extension
 ]);
 
@@ -73,6 +73,83 @@ $app->map('render', function(string $template, array $data) use ($app): void {
     echo $app->view()->render($template, $data);
 });
 ```
+
+## Path Configuration
+
+CommentTemplate provides intelligent path handling for both relative and absolute paths:
+
+### Public Path
+
+The **Public Path** is the root directory of your web application, typically where `index.php` resides. This is the document root that web servers serve files from.
+
+```php
+// Example: if your index.php is at /var/www/html/myapp/index.php
+$template->setPublicPath('/var/www/html/myapp');  // Root directory
+
+// Windows example: if your index.php is at C:\xampp\htdocs\myapp\index.php
+$template->setPublicPath('C:\\xampp\\htdocs\\myapp');
+```
+
+### Templates Path Configuration
+
+Templates path supports both relative and absolute paths:
+
+```php
+$template = new Engine();
+$template->setPublicPath('/var/www/html/myapp');  // Root directory (where index.php is)
+
+// Relative paths - automatically combined with public path
+$template->setSkinPath('views');           // → /var/www/html/myapp/views/
+$template->setSkinPath('templates/pages'); // → /var/www/html/myapp/templates/pages/
+
+// Absolute paths - used as-is (Unix/Linux)
+$template->setSkinPath('/var/www/templates');      // → /var/www/templates/
+$template->setSkinPath('/full/path/to/templates'); // → /full/path/to/templates/
+
+// Windows absolute paths
+$template->setSkinPath('C:\\www\\templates');     // → C:\www\templates\
+$template->setSkinPath('D:/projects/templates');  // → D:/projects/templates/
+
+// UNC paths (Windows network shares)
+$template->setSkinPath('\\\\server\\share\\templates'); // → \\server\share\templates\
+```
+
+### Asset Path Configuration
+
+Asset path also supports both relative and absolute paths:
+
+```php
+// Relative paths - automatically combined with public path
+$template->setAssetPath('assets');        // → /var/www/html/myapp/assets/
+$template->setAssetPath('static/files');  // → /var/www/html/myapp/static/files/
+
+// Absolute paths - used as-is (Unix/Linux)
+$template->setAssetPath('/var/www/cdn');           // → /var/www/cdn/
+$template->setAssetPath('/full/path/to/assets');   // → /full/path/to/assets/
+
+// Windows absolute paths
+$template->setAssetPath('C:\\www\\static');       // → C:\www\static\
+$template->setAssetPath('D:/projects/assets');    // → D:/projects/assets/
+
+// UNC paths (Windows network shares)
+$template->setAssetPath('\\\\server\\share\\assets'); // → \\server\share\assets\
+```
+
+**Smart Path Detection:**
+
+- **Relative Paths**: No leading separators (`/`, `\`) or drive letters
+- **Unix Absolute**: Starts with `/` (e.g., `/var/www/assets`)
+- **Windows Absolute**: Starts with drive letter (e.g., `C:\www`, `D:/assets`)
+- **UNC Paths**: Starts with `\\` (e.g., `\\server\share`)
+
+**How it works:**
+
+- All paths are automatically resolved based on type (relative vs absolute)
+- Relative paths are combined with the public path
+- `@css` and `@js` create minified files in: `{resolvedAssetPath}/css/` or `{resolvedAssetPath}/js/`
+- `@asset` copies single files to: `{resolvedAssetPath}/{relativePath}`
+- `@assetDir` copies directories to: `{resolvedAssetPath}/{relativePath}`
+- Smart caching: files only copied when source is newer than destination
 
 ## Template Directives
 
@@ -231,6 +308,26 @@ const imageData = '<!--@base64(images/icon.png)-->';
 ```html
 {$content|striptag|trim|escape}      <!-- Chain multiple filters -->
 ```
+
+### Comments
+
+Template comments are completely removed from the output and won't appear in the final HTML:
+
+```html
+{* This is a single-line template comment *}
+
+{* 
+   This is a multi-line 
+   template comment 
+   that spans several lines
+*}
+
+<h1>{$title}</h1>
+{* Debug comment: checking if title variable works *}
+<p>{$content}</p>
+```
+
+**Note**: Template comments `{* ... *}` are different from HTML comments `<!-- ... -->`. Template comments are removed during processing and never reach the browser.
 
 ## Example Project Structure
 

--- a/content/v3/fr/awesome-plugins/comment_template.md
+++ b/content/v3/fr/awesome-plugins/comment_template.md
@@ -33,14 +33,14 @@ use KnifeLemon\CommentTemplate\Engine;
 $app = Flight::app();
 
 $app->register('view', Engine::class, [], function (Engine $engine) use ($app) {
-    // Où vos fichiers de templates sont stockés
-    $engine->setTemplatesPath(__DIR__ . '/views');
+    // Répertoire racine (où se trouve index.php) - la racine du document de votre application web
+    $engine->setPublicPath(__DIR__);
     
-    // D'où vos actifs publics seront servis
-    $engine->setPublicPath(__DIR__ . '/public');
+    // Répertoire des fichiers de templates - supporte les chemins relatifs et absolus
+    $engine->setSkinPath('views');             // Relatif au chemin public
     
-    // Où les actifs compilés seront stockés
-    $engine->setAssetPath('assets');
+    // Où les actifs compilés seront stockés - supporte les chemins relatifs et absolus
+    $engine->setAssetPath('assets');           // Relatif au chemin public
     
     // Extension des fichiers de template
     $engine->setFileExtension('.php');
@@ -63,9 +63,9 @@ $app = Flight::app();
 
 // __construct(string $publicPath = "", string $skinPath = "", string $assetPath = "", string $fileExtension = "")
 $app->register('view', Engine::class, [
-    __DIR__ . '/public',    // publicPath - d'où les actifs seront servis
-    __DIR__ . '/views',     // skinPath - où les fichiers de templates sont stockés  
-    'assets',               // assetPath - où les actifs compilés seront stockés
+    __DIR__,                // publicPath - répertoire racine (où se trouve index.php)
+    'views',                // skinPath - chemin des templates (supporte relatif/absolu)
+    'assets',               // assetPath - chemin des actifs compilés (supporte relatif/absolu)
     '.php'                  // fileExtension - extension des fichiers de template
 ]);
 
@@ -73,6 +73,83 @@ $app->map('render', function(string $template, array $data) use ($app): void {
     echo $app->view()->render($template, $data);
 });
 ```
+
+## Configuration des Chemins
+
+CommentTemplate offre une gestion intelligente des chemins pour les chemins relatifs et absolus :
+
+### Chemin Public
+
+Le **Chemin Public** est le répertoire racine de votre application web, généralement où se trouve `index.php`. C'est la racine du document que les serveurs web utilisent pour servir les fichiers.
+
+```php
+// Exemple : si votre index.php est à /var/www/html/myapp/index.php
+$template->setPublicPath('/var/www/html/myapp');  // Répertoire racine
+
+// Exemple Windows : si votre index.php est à C:\xampp\htdocs\myapp\index.php
+$template->setPublicPath('C:\\xampp\\htdocs\\myapp');
+```
+
+### Configuration du Chemin des Templates
+
+Le chemin des templates supporte les chemins relatifs et absolus :
+
+```php
+$template = new Engine();
+$template->setPublicPath('/var/www/html/myapp');  // Répertoire racine (où se trouve index.php)
+
+// Chemins relatifs - automatiquement combinés avec le chemin public
+$template->setSkinPath('views');           // → /var/www/html/myapp/views/
+$template->setSkinPath('templates/pages'); // → /var/www/html/myapp/templates/pages/
+
+// Chemins absolus - utilisés tel quel (Unix/Linux)
+$template->setSkinPath('/var/www/templates');      // → /var/www/templates/
+$template->setSkinPath('/full/path/to/templates'); // → /full/path/to/templates/
+
+// Chemins absolus Windows
+$template->setSkinPath('C:\\www\\templates');     // → C:\www\templates\
+$template->setSkinPath('D:/projects/templates');  // → D:/projects/templates/
+
+// Chemins UNC (partages réseau Windows)
+$template->setSkinPath('\\\\server\\share\\templates'); // → \\server\share\templates\
+```
+
+### Configuration du Chemin des Actifs
+
+Le chemin des actifs supporte aussi les chemins relatifs et absolus :
+
+```php
+// Chemins relatifs - automatiquement combinés avec le chemin public
+$template->setAssetPath('assets');        // → /var/www/html/myapp/assets/
+$template->setAssetPath('static/files');  // → /var/www/html/myapp/static/files/
+
+// Chemins absolus - utilisés tel quel (Unix/Linux)
+$template->setAssetPath('/var/www/cdn');           // → /var/www/cdn/
+$template->setAssetPath('/full/path/to/assets');   // → /full/path/to/assets/
+
+// Chemins absolus Windows
+$template->setAssetPath('C:\\www\\static');       // → C:\www\static\
+$template->setAssetPath('D:/projects/assets');    // → D:/projects/assets/
+
+// Chemins UNC (partages réseau Windows)
+$template->setAssetPath('\\\\server\\share\\assets'); // → \\server\share\assets\
+```
+
+**Détection Intelligente des Chemins :**
+
+- **Chemins Relatifs** : Pas de séparateurs de début (`/`, `\`) ou de lettres de lecteur
+- **Unix Absolu** : Commence par `/` (ex : `/var/www/assets`)
+- **Windows Absolu** : Commence par une lettre de lecteur (ex : `C:\www`, `D:/assets`)
+- **Chemins UNC** : Commence par `\\` (ex : `\\server\share`)
+
+**Comment ça fonctionne :**
+
+- Tous les chemins sont automatiquement résolus selon le type (relatif vs absolu)
+- Les chemins relatifs sont combinés avec le chemin public
+- `@css` et `@js` créent des fichiers minifiés dans : `{resolvedAssetPath}/css/` ou `{resolvedAssetPath}/js/`
+- `@asset` copie les fichiers uniques vers : `{resolvedAssetPath}/{relativePath}`
+- `@assetDir` copie les répertoires vers : `{resolvedAssetPath}/{relativePath}`
+- Cache intelligent : les fichiers ne sont copiés que lorsque la source est plus récente que la destination
 
 ## Directives de Template
 
@@ -227,10 +304,30 @@ const imageData = '<!--@base64(images/icon.png)-->';
 {$name|concat= (Admin)}              <!-- Concaténer du texte -->
 ```
 
-#### Commandes de Variables
+#### Chaîner Plusieurs Filtres
 ```html
 {$content|striptag|trim|escape}      <!-- Chaîner plusieurs filtres -->
 ```
+
+### Commentaires
+
+Les commentaires de template sont entièrement supprimés de la sortie et n'apparaissent pas dans le HTML final :
+
+```html
+{* Ceci est un commentaire de template sur une ligne *}
+
+{* 
+   Ceci est un commentaire de template
+   multi-lignes qui s'étend sur
+   plusieurs lignes
+*}
+
+<h1>{$title}</h1>
+{* Commentaire de débogage : vérifie si la variable title fonctionne *}
+<p>{$content}</p>
+```
+
+**Note** : Les commentaires de template `{* ... *}` sont différents des commentaires HTML `<!-- ... -->`. Les commentaires de template sont supprimés lors du traitement et n'atteignent jamais le navigateur.
 
 ## Structure de Projet Exemple
 

--- a/content/v3/uk/awesome-plugins/comment_template.md
+++ b/content/v3/uk/awesome-plugins/comment_template.md
@@ -33,14 +33,14 @@ use KnifeLemon\CommentTemplate\Engine;
 $app = Flight::app();
 
 $app->register('view', Engine::class, [], function (Engine $engine) use ($app) {
-    // Де зберігаються ваші файли шаблонів
-    $engine->setTemplatesPath(__DIR__ . '/views');
+    // Кореневий каталог (де знаходиться index.php) - кореневий документ вашого веб-застосунку
+    $engine->setPublicPath(__DIR__);
     
-    // Де ваші публічні активи будуть обслуговуватися
-    $engine->setPublicPath(__DIR__ . '/public');
+    // Каталог файлів шаблонів - підтримує відносні та абсолютні шляхи
+    $engine->setSkinPath('views');             // Відносно публічного шляху
     
-    // Де зберігатимуться скомпільовані активи
-    $engine->setAssetPath('assets');
+    // Де зберігатимуться скомпільовані активи - підтримує відносні та абсолютні шляхи
+    $engine->setAssetPath('assets');           // Відносно публічного шляху
     
     // Розширення файлу шаблону
     $engine->setFileExtension('.php');
@@ -63,9 +63,9 @@ $app = Flight::app();
 
 // __construct(string $publicPath = "", string $skinPath = "", string $assetPath = "", string $fileExtension = "")
 $app->register('view', Engine::class, [
-    __DIR__ . '/public',    // publicPath - де активи будуть обслуговуватися
-    __DIR__ . '/views',     // skinPath - де зберігаються файли шаблонів  
-    'assets',               // assetPath - де зберігатимуться скомпільовані активи
+    __DIR__,                // publicPath - кореневий каталог (де знаходиться index.php)
+    'views',                // skinPath - шлях шаблонів (підтримує відносні/абсолютні)
+    'assets',               // assetPath - шлях скомпільованих активів (підтримує відносні/абсолютні)
     '.php'                  // fileExtension - розширення файлу шаблону
 ]);
 
@@ -73,6 +73,83 @@ $app->map('render', function(string $template, array $data) use ($app): void {
     echo $app->view()->render($template, $data);
 });
 ```
+
+## Конфігурація шляхів
+
+CommentTemplate забезпечує інтелектуальну обробку шляхів для відносних та абсолютних шляхів:
+
+### Публічний шлях
+
+**Публічний шлях** - це кореневий каталог вашого веб-застосунку, зазвичай де знаходиться `index.php`. Це кореневий документ, з якого веб-сервери надають файли.
+
+```php
+// Приклад: якщо ваш index.php знаходиться в /var/www/html/myapp/index.php
+$template->setPublicPath('/var/www/html/myapp');  // Кореневий каталог
+
+// Приклад Windows: якщо ваш index.php знаходиться в C:\xampp\htdocs\myapp\index.php
+$template->setPublicPath('C:\\xampp\\htdocs\\myapp');
+```
+
+### Конфігурація шляху шаблонів
+
+Шлях шаблонів підтримує як відносні, так і абсолютні шляхи:
+
+```php
+$template = new Engine();
+$template->setPublicPath('/var/www/html/myapp');  // Кореневий каталог (де знаходиться index.php)
+
+// Відносні шляхи - автоматично поєднуються з публічним шляхом
+$template->setSkinPath('views');           // → /var/www/html/myapp/views/
+$template->setSkinPath('templates/pages'); // → /var/www/html/myapp/templates/pages/
+
+// Абсолютні шляхи - використовуються як є (Unix/Linux)
+$template->setSkinPath('/var/www/templates');      // → /var/www/templates/
+$template->setSkinPath('/full/path/to/templates'); // → /full/path/to/templates/
+
+// Абсолютні шляхи Windows
+$template->setSkinPath('C:\\www\\templates');     // → C:\www\templates\
+$template->setSkinPath('D:/projects/templates');  // → D:/projects/templates/
+
+// UNC шляхи (мережеві ресурси Windows)
+$template->setSkinPath('\\\\server\\share\\templates'); // → \\server\share\templates\
+```
+
+### Конфігурація шляху активів
+
+Шлях активів також підтримує як відносні, так і абсолютні шляхи:
+
+```php
+// Відносні шляхи - автоматично поєднуються з публічним шляхом
+$template->setAssetPath('assets');        // → /var/www/html/myapp/assets/
+$template->setAssetPath('static/files');  // → /var/www/html/myapp/static/files/
+
+// Абсолютні шляхи - використовуються як є (Unix/Linux)
+$template->setAssetPath('/var/www/cdn');           // → /var/www/cdn/
+$template->setAssetPath('/full/path/to/assets');   // → /full/path/to/assets/
+
+// Абсолютні шляхи Windows
+$template->setAssetPath('C:\\www\\static');       // → C:\www\static\
+$template->setAssetPath('D:/projects/assets');    // → D:/projects/assets/
+
+// UNC шляхи (мережеві ресурси Windows)
+$template->setAssetPath('\\\\server\\share\\assets'); // → \\server\share\assets\
+```
+
+**Розумне визначення шляхів:**
+
+- **Відносні шляхи**: Без початкових роздільників (`/`, `\`) або літер дисків
+- **Unix абсолютні**: Починаються з `/` (напр. `/var/www/assets`)
+- **Windows абсолютні**: Починаються з літери диска (напр. `C:\www`, `D:/assets`)
+- **UNC шляхи**: Починаються з `\\` (напр. `\\server\share`)
+
+**Як це працює:**
+
+- Всі шляхи автоматично розв'язуються на основі типу (відносний vs абсолютний)
+- Відносні шляхи поєднуються з публічним шляхом
+- `@css` та `@js` створюють мінімізовані файли в: `{resolvedAssetPath}/css/` або `{resolvedAssetPath}/js/`
+- `@asset` копіює окремі файли до: `{resolvedAssetPath}/{relativePath}`
+- `@assetDir` копіює каталоги до: `{resolvedAssetPath}/{relativePath}`
+- Розумне кешування: файли копіюються лише коли джерело новіше за призначення
 
 ## Директиви шаблонів
 
@@ -227,10 +304,30 @@ const imageData = '<!--@base64(images/icon.png)-->';
 {$name|concat= (Admin)}              <!-- Об'єднати текст -->
 ```
 
-#### Команди змінних
+#### Ланцюжок кількох фільтрів
 ```html
 {$content|striptag|trim|escape}      <!-- Ланцюжок кількох фільтрів -->
 ```
+
+### Коментарі
+
+Коментарі шаблонів повністю видаляються з виводу і не з'являються в кінцевому HTML:
+
+```html
+{* Це однорядковий коментар шаблону *}
+
+{* 
+   Це багаторядковий
+   коментар шаблону 
+   на кілька рядків
+*}
+
+<h1>{$title}</h1>
+{* Відлагоджувальний коментар: перевіряємо чи працює змінна title *}
+<p>{$content}</p>
+```
+
+**Примітка**: Коментарі шаблонів `{* ... *}` відрізняються від HTML коментарів `<!-- ... -->`. Коментарі шаблонів видаляються під час обробки і ніколи не досягають браузера.
 
 ## Приклад структури проекту
 


### PR DESCRIPTION
Sorry. Fixed incorrect content across all language versions.

- Method fix: `setTemplatesPath` → `setSkinPath`
- Added path configuration examples  
- Added template comment syntax
- All languages translate