### PR TITLE
Update runway.md

### DIFF
--- a/content/v3/en/awesome-plugins/runway.md
+++ b/content/v3/en/awesome-plugins/runway.md
@@ -138,7 +138,7 @@ class ExampleCommand extends AbstractBaseCommand
      *
      * @return void
      */
-    public function execute(string $controller)
+    public function execute()
     {
         $io = $this->app()->io();
 


### PR DESCRIPTION
Removed function inputs. If these inputs are used, the function doesn't work. In `skeleton` there's an example command, without the inputs, and removing them here makes the example work.